### PR TITLE
Make necessary mods public

### DIFF
--- a/rust/libits-client/src/mqtt/topic/mod.rs
+++ b/rust/libits-client/src/mqtt/topic/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod geo_extension;
+pub mod geo_extension;
 mod message_type;
 mod parse_error;
 mod queue;

--- a/rust/libits-client/src/reception/exchange/mod.rs
+++ b/rust/libits-client/src/reception/exchange/mod.rs
@@ -8,12 +8,12 @@ use crate::reception::exchange::reference_position::ReferencePosition;
 use crate::reception::mortal::{now, Mortal};
 use crate::reception::Reception;
 
-pub(crate) mod collective_perception_message;
-pub(crate) mod cooperative_awareness_message;
-pub(crate) mod decentralized_environmental_notification_message;
-pub(crate) mod message;
+pub mod collective_perception_message;
+pub mod cooperative_awareness_message;
+pub mod decentralized_environmental_notification_message;
+pub mod message;
 pub mod mobile;
-pub(crate) mod reference_position;
+pub mod reference_position;
 
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/rust/libits-client/src/reception/mortal.rs
+++ b/rust/libits-client/src/reception/mortal.rs
@@ -39,6 +39,6 @@ pub(crate) fn timestamp(etsi_timestamp: u128) -> u128 {
 /// Unit: millisecond since ETSI epoch (2004/01/01, so 1072915195000).
 /// Time at which a new DENM, an update DENM or a cancellation DENM is generated.
 /// utcStartOf2004(0), oneMillisecAfterUTCStartOf2004(1)
-pub(crate) fn etsi_timestamp(timestamp: u128) -> u128 {
+pub fn etsi_timestamp(timestamp: u128) -> u128 {
     timestamp - 1072915195000
 }


### PR DESCRIPTION
Changes
---------

Extend visibility to public on modules required by external usage

How to test
------------

1. Check out the `its_client_dependency` branch on jam-detector repository
2. Build that branch  
**=> Build must success**
3. Run all tests
**=> All tests must build and pass**