### PR TITLE
Manage perceived object

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -40,6 +40,6 @@ jobs:
           cd rust/its-client
           cargo publish --token ${{ secrets.CRATES_IO }}
       - name: Publish the its binary using the copycat example
-          run: |
-            cd rust/its-client
-            cargo publish --token ${{ secrets.CRATES_IO }}
+        run: |
+          cd rust/its-client
+          cargo publish --token ${{ secrets.CRATES_IO }}

--- a/rust/libits-client/Cargo.toml
+++ b/rust/libits-client/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 rumqttc = "0.8"
 pin-utils = "0.1"
 navigation = "0.1"
+cheap-ruler = "0.3.0"
 rustls = "0.19"
 
 [dependencies.serde]

--- a/rust/libits-client/src/reception/exchange/mobile.rs
+++ b/rust/libits-client/src/reception/exchange/mobile.rs
@@ -15,4 +15,123 @@ pub trait Mobile {
         }
         false
     }
+
+    fn heading_in_degrees(&self) -> Option<f64> {
+        if let Some(heading) = self.heading() {
+            return Some(heading_in_degrees(heading));
+        }
+        None
+    }
+
+    fn speed_in_meter_per_second(&self) -> Option<f64> {
+        if let Some(speed) = self.speed() {
+            return Some(speed_in_meter_per_second(speed));
+        }
+        None
+    }
+
+    fn speed_in_kilometer_per_hour(&self) -> Option<f64> {
+        if let Some(speed) = self.speed() {
+            return Some(speed_in_kilometer_per_hour(speed));
+        }
+        None
+    }
+}
+
+pub(crate) fn heading_in_degrees(heading: u16) -> f64 {
+    heading as f64 / 10.0
+}
+
+pub(crate) fn speed_in_meter_per_second(speed: u16) -> f64 {
+    speed as f64 / 100.0
+}
+
+pub(crate) fn speed_in_kilometer_per_hour(speed: u16) -> f64 {
+    speed_in_meter_per_second(speed) * 3.6
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::reception::exchange::mobile::Mobile;
+    use crate::reception::exchange::reference_position::ReferencePosition;
+
+    struct StoppedMobileStub {}
+
+    impl Mobile for StoppedMobileStub {
+        fn mobile_id(&self) -> u32 {
+            todo!()
+        }
+
+        fn position(&self) -> &ReferencePosition {
+            todo!()
+        }
+
+        fn speed(&self) -> Option<u16> {
+            Some(35)
+        }
+
+        fn heading(&self) -> Option<u16> {
+            Some(1800) // south
+        }
+    }
+
+    struct MovingMobileStub {}
+
+    impl Mobile for MovingMobileStub {
+        fn mobile_id(&self) -> u32 {
+            todo!()
+        }
+
+        fn position(&self) -> &ReferencePosition {
+            todo!()
+        }
+
+        fn speed(&self) -> Option<u16> {
+            Some(37)
+        }
+
+        fn heading(&self) -> Option<u16> {
+            Some(900) // east
+        }
+    }
+
+    #[test]
+    fn it_can_check_if_stopped() {
+        assert!(StoppedMobileStub {}.stopped());
+    }
+
+    #[test]
+    fn it_can_check_if_moving() {
+        assert_eq!(MovingMobileStub {}.stopped(), false);
+    }
+
+    #[test]
+    fn it_can_provide_heading_in_degrees() {
+        // south
+        assert_eq!(StoppedMobileStub {}.heading_in_degrees(), Some(180.0));
+        // north
+        assert_eq!(MovingMobileStub {}.heading_in_degrees(), Some(90.0));
+    }
+
+    #[test]
+    fn it_can_provide_speed_in_meter_per_second() {
+        // south
+        assert_eq!(StoppedMobileStub {}.speed_in_meter_per_second(), Some(0.35));
+        // north
+        assert_eq!(MovingMobileStub {}.speed_in_meter_per_second(), Some(0.37));
+    }
+
+    #[test]
+    fn it_can_provide_speed_in_kilometer_per_hour() {
+        // south
+        assert_eq!(
+            StoppedMobileStub {}.speed_in_kilometer_per_hour(),
+            Some(1.26)
+        );
+        // north
+        assert_eq!(
+            MovingMobileStub {}.speed_in_kilometer_per_hour(),
+            Some(1.332)
+        );
+    }
 }

--- a/rust/libits-client/src/reception/exchange/mobile_perceived_object.rs
+++ b/rust/libits-client/src/reception/exchange/mobile_perceived_object.rs
@@ -1,0 +1,160 @@
+use core::cmp;
+
+use crate::reception::exchange::mobile;
+use crate::reception::exchange::mobile::Mobile;
+use crate::reception::exchange::perceived_object::PerceivedObject;
+use crate::reception::exchange::reference_position::ReferencePosition;
+
+#[derive(Debug)]
+pub struct MobilePerceivedObject {
+    pub perceived_object: PerceivedObject,
+    pub reference_position: ReferencePosition,
+}
+
+impl MobilePerceivedObject {
+    pub(crate) fn new(
+        perceived_object: PerceivedObject,
+        cpm_position: &ReferencePosition,
+        cpm_heading: u16,
+    ) -> Self {
+        let computed_reference_position = compute_position(
+            perceived_object.distance.x_distance,
+            perceived_object.distance.y_distance,
+            cpm_position,
+            cpm_heading,
+        );
+        Self {
+            perceived_object,
+            reference_position: computed_reference_position,
+        }
+    }
+}
+
+impl Mobile for MobilePerceivedObject {
+    fn mobile_id(&self) -> u32 {
+        self.perceived_object.object_id as u32
+    }
+
+    fn position(&self) -> &ReferencePosition {
+        &self.reference_position
+    }
+
+    fn speed(&self) -> Option<u16> {
+        // TODO compute it from Speed
+        None
+    }
+
+    fn heading(&self) -> Option<u16> {
+        // not known from a sensor
+        // TODO compute it using historical position if needed
+        None
+    }
+}
+
+impl cmp::PartialEq for MobilePerceivedObject {
+    fn eq(&self, other: &Self) -> bool {
+        self.perceived_object == other.perceived_object
+            && self.reference_position == other.reference_position
+    }
+}
+
+fn compute_position(
+    x_distance: i32,
+    y_distance: i32,
+    cpm_position: &ReferencePosition,
+    cpm_heading: u16,
+) -> ReferencePosition {
+    let x_offset_meters = x_distance as f64 / 100.0;
+    let y_offset_meters = y_distance as f64 / 100.0;
+    let heading_in_degrees = mobile::heading_in_degrees(cpm_heading);
+    return cpm_position
+        .get_destination(x_offset_meters, heading_in_degrees)
+        .get_destination(y_offset_meters, (heading_in_degrees - 90.0 + 360.0) % 360.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::reception::exchange::mobile_perceived_object::{
+        compute_position, MobilePerceivedObject,
+    };
+    use crate::reception::exchange::perceived_object::{Distance, PerceivedObject};
+    use crate::reception::exchange::reference_position::ReferencePosition;
+
+    #[test]
+    fn it_can_compute_a_position() {
+        //south with x
+        assert_eq!(
+            compute_position(
+                50000,
+                0,
+                &ReferencePosition {
+                    latitude: 434667520,
+                    longitude: 1205862,
+                    altitude: 220000,
+                },
+                1800,
+            ),
+            ReferencePosition {
+                latitude: 434622516,
+                longitude: 1205862,
+                altitude: 220000,
+            }
+        );
+        // east with y
+        assert_eq!(
+            compute_position(
+                0,
+                10000,
+                &ReferencePosition {
+                    latitude: 434667520,
+                    longitude: 1205862,
+                    altitude: 220000,
+                },
+                1800,
+            ),
+            ReferencePosition {
+                latitude: 434667520,
+                longitude: 1218219,
+                altitude: 220000,
+            }
+        );
+    }
+
+    #[test]
+    fn create_a_new() {
+        //south east with x and y
+        assert_eq!(
+            MobilePerceivedObject::new(
+                PerceivedObject {
+                    object_id: 1,
+                    distance: Distance {
+                        x_distance: 50000,
+                        y_distance: 10000,
+                    },
+                    ..Default::default()
+                },
+                &ReferencePosition {
+                    latitude: 434667520,
+                    longitude: 1205862,
+                    altitude: 220000,
+                },
+                1800,
+            ),
+            MobilePerceivedObject {
+                perceived_object: PerceivedObject {
+                    object_id: 1,
+                    distance: Distance {
+                        x_distance: 50000,
+                        y_distance: 10000,
+                    },
+                    ..Default::default()
+                },
+                reference_position: ReferencePosition {
+                    latitude: 434622516,
+                    longitude: 1218218,
+                    altitude: 220000,
+                },
+            }
+        );
+    }
+}

--- a/rust/libits-client/src/reception/exchange/mod.rs
+++ b/rust/libits-client/src/reception/exchange/mod.rs
@@ -13,6 +13,8 @@ pub mod cooperative_awareness_message;
 pub mod decentralized_environmental_notification_message;
 pub mod message;
 pub mod mobile;
+pub mod mobile_perceived_object;
+pub mod perceived_object;
 pub mod reference_position;
 
 #[serde_with::skip_serializing_none]

--- a/rust/libits-client/src/reception/exchange/perceived_object.rs
+++ b/rust/libits-client/src/reception/exchange/perceived_object.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PerceivedObject {
+    pub object_id: u8,
+    pub time_of_measurement: i16,
+    pub object_confidence: u8,
+    pub distance: Distance,
+    pub distance_confidence: DistanceConfidence,
+    pub speed: Speed,
+    pub speed_confidence: SpeedConfidence,
+    pub object_ref_point: u8,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
+pub struct Distance {
+    pub x_distance: i32,
+    pub y_distance: i32,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DistanceConfidence {
+    pub x_distance: u8,
+    pub y_distance: u8,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
+pub struct Speed {
+    pub x_speed: i16,
+    pub y_speed: i16,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SpeedConfidence {
+    pub x_speed: u8,
+    pub y_speed: u8,
+}


### PR DESCRIPTION
Fix #14 

Fix #9

Fix #10 

**How to test:**

No its client provided using CPM's for now: you can test again like for https://github.com/tigroo31/its-client/pull/13. The new Mobile Perceived Object list must be used to process them more or less as CAM's

When the PR will be merged, let's verify the is now well deployed.