### PR TITLE
Add cause's type and id to DENM publish monitoring

### DIFF
--- a/rust/its-client/Cargo.toml
+++ b/rust/its-client/Cargo.toml
@@ -27,7 +27,7 @@ version = "0.18.0"
 features = ["async", "compress"]
 
 [dependencies.libits-client]
-version = "0.2"
+version = "0.3"
 path="../libits-client"
 
 [dependencies.pretty_env_logger]

--- a/rust/libits-client/Cargo.toml
+++ b/rust/libits-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libits-client"
-version = "0.2.7"
+version = "0.3.0"
 authors = ["Frédéric Gardes <frederic.gardes@orange.com>", "Nicolas Buffon <nicolas.buffon@orange.com>"]
 license = "Apache-2.0"
 description = "library to connect on an ITS MQTT server"

--- a/rust/libits-client/src/analyse/cause.rs
+++ b/rust/libits-client/src/analyse/cause.rs
@@ -1,0 +1,34 @@
+use crate::reception::exchange::message::Message;
+use crate::reception::exchange::Exchange;
+use std::fmt::Formatter;
+
+pub struct Cause {
+    pub m_type: String,
+    pub id: String,
+}
+
+impl std::fmt::Display for Cause {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "/cause_type:{}/cause_id:{}", self.m_type, self.id)
+    }
+}
+
+impl Cause {
+    fn new(m_type: String, id: String) -> Self {
+        Self { m_type, id }
+    }
+
+    pub fn from_exchange(exchange: &Exchange) -> Option<Cause> {
+        return match &exchange.message {
+            Message::CAM(message) => Some(Cause::new(
+                exchange.type_field.clone(),
+                format!("{}/{}", message.station_id, message.generation_delta_time),
+            )),
+            Message::CPM(message) => Some(Cause::new(
+                exchange.type_field.clone(),
+                format!("{}/{}", message.station_id, message.generation_delta_time),
+            )),
+            _ => None,
+        };
+    }
+}

--- a/rust/libits-client/src/analyse/mod.rs
+++ b/rust/libits-client/src/analyse/mod.rs
@@ -1,3 +1,4 @@
 pub mod analyser;
+pub mod cause;
 pub mod configuration;
 pub mod item;

--- a/rust/libits-client/src/monitor.rs
+++ b/rust/libits-client/src/monitor.rs
@@ -1,9 +1,16 @@
+use crate::analyse::cause::Cause;
 use crate::reception::exchange::message::Message;
 use crate::reception::exchange::Exchange;
 use crate::reception::mortal::now;
 
 // TODO implement the Rust macro monitor!
-pub fn monitor(exchange: &Exchange, direction: &str, component: String, partner: String) {
+pub fn monitor(
+    exchange: &Exchange,
+    cause: Option<Cause>,
+    direction: &str,
+    component: String,
+    partner: String,
+) {
     match &exchange.message {
         // FIXME find how to call position() on any Message implementing Mobile
         Message::CAM(message) => {
@@ -22,7 +29,7 @@ pub fn monitor(exchange: &Exchange, direction: &str, component: String, partner:
         Message::DENM(message) => {
             // log to monitoring platform
             println!(
-                "{} {} {} {} {}/{}/{}/{}/{} at {}",
+                "{} {} {} {} {}/{}/{}/{}/{}{} at {}",
                 component,
                 exchange.type_field,
                 direction,
@@ -35,6 +42,7 @@ pub fn monitor(exchange: &Exchange, direction: &str, component: String, partner:
                 message.management_container.action_id.sequence_number,
                 message.management_container.reference_time,
                 message.management_container.detection_time,
+                get_cause_str(cause),
                 now()
             );
         }
@@ -51,5 +59,12 @@ pub fn monitor(exchange: &Exchange, direction: &str, component: String, partner:
                 now()
             );
         }
+    };
+}
+
+fn get_cause_str(cause: Option<Cause>) -> String {
+    return match cause {
+        Some(cause) => format!("/cause_type:{}/cause_id:{}", cause.m_type, cause.id),
+        None => String::new(),
     };
 }

--- a/rust/libits-copycat/Cargo.toml
+++ b/rust/libits-copycat/Cargo.toml
@@ -19,5 +19,5 @@ timer = "0.2"
 chrono = "0.4"
 
 [dependencies.libits-client]
-version = "0.2"
+version = "0.3"
 path="../libits-client"


### PR DESCRIPTION
New features
-----------------

Add cause's type and id to monitoring line when publishing DENM

How to test
---------------

1. Start the jam detector on either local broker or cloud broker  
    *NB: you need to edit the `Cargo.toml` files to use the local code base of the lib*
2. Launch any scenario that generates DENM
3. Check the logs of the jam detector  
**=> DENM published following CAM reception must be monitored with the CAM's id as cause**
> crunch-clion_41470 cam received_on broker/5GCroCo/inQueue/v2x/cam/ora_car_0E02 **4086369794/16133** at 1637593855939  
> crunch-clion_41470 denm sent_on broker/5GCroCo/inQueue/v2x/denm/crunch-clion_41470 4086369794/41470/4/564678633757/564678660940/**cause_type:cam/cause_id:4086369794/16133** at 1637593855941  

**=> DENM reception monitoring does not includes any cause information**  
> crunch-clion_41470 denm received_on broker/5GCroCo/inQueue/v2x/denm/crunch-clion_41470 4086369794/41470/4/564678633757/564678660940 at 1637593855941  
> crunch-clion_41470 denm received_on broker/5GCroCo/inQueue/v2x/denm/crunch-clion_41470 4086369794/41470/4/564678633757/564678660940 at 1637593855941  